### PR TITLE
Set initial value of the selection count.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -142,7 +142,7 @@
             <div class="flex-util">
                 <p>Words: <span id="wordcount">###</span></p>
                 <p>Characters: <span id="charcount">###</span></p>
-                <p>Selection: <span id="selectiondetails">###</span></p>
+                <p>Selection: <span id="selectiondetails">0</span></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The selection count should be initially set to 0 as the page cannot (as far as I'm aware) be loaded with text already selected. This prevents it being set to `###` until a user selects text for the first time.

Alternatively something like this could be called inside the `window.onload` function, but I don't think it has any benefits in this situation:
```js
let selection = window.getSelection();
selectionDetailsSpan.textContent = selection.toString().length;
```